### PR TITLE
Refactor whitespace and formatting in ip6addr_functions, test_libip6a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-## Giving local DNS names to IPv6 SLAAC addresses 
-#### OpenWrt/LEDE shell script
+# Giving local DNS names to IPv6 SLAAC addresses
+
+## OpenWrt/LEDE shell script
 
 ## Synopsis
 
@@ -33,92 +34,92 @@ When using ip6neigh, names are applied to local IPv6 hosts, rather than cryptic 
 
 1. Install dependencies, `curl` and `ip-full`
 
-	```
-	# opkg update
-	# opkg install curl ip-full
-	```
+    ```
+    # opkg update
+    # opkg install curl ip-full
+    ```
 
-	**NOTE:** Special procedure for LEDE systems: When using LEDE v17.01.**0**, the `ip-full` package needs to be upgraded to a newer build which has fixed the 'ip monitor' bug. For 17.01.x systems, please navigate to [https://downloads.lede-project.org/snapshots/packages/](https://downloads.lede-project.org/snapshots/packages/) , find your platform directory, download `ip-full_4.4.0-X_platform.ipk` (where X corresponds to the latest version) and install it on the router. For OpenWrt 18.06.x install the package from 17.01.x by navigating to: [http://downloads.openwrt.org/releases/17.01.6/packages/[arch]/base/](http://downloads.openwrt.org/releases/17.01.6/packages).
-	
+    **NOTE:** Special procedure for LEDE systems: When using LEDE v17.01.**0**, the `ip-full` package needs to be upgraded to a newer build which has fixed the 'ip monitor' bug. For 17.01.x systems, please navigate to [https://downloads.lede-project.org/snapshots/packages/](https://downloads.lede-project.org/snapshots/packages/) , find your platform directory, download `ip-full_4.4.0-X_platform.ipk` (where X corresponds to the latest version) and install it on the router. For OpenWrt 18.06.x install the package from 17.01.x by navigating to: [http://downloads.openwrt.org/releases/17.01.6/packages/[arch]/base/](http://downloads.openwrt.org/releases/17.01.6/packages).
+
 Example for the x86_64 platform:
-	
-	```
-	# cd /tmp
-	# wget http://downloads.lede-project.org/snapshots/packages/x86_64/base/ip-full_4.4.0-10_x86_64.ipk
-	# opkg remove ip-full
-	# opkg install ip-full_4.4.0-10_x86_64.ipk
-	# rm ip-full_4.4.0-10_x86_64.ipk
-	```
 
-	**Hint:** When copying the download URL from your browser, change `https` to `http` like the example above to allow downloading without having to install CA certificates.
-	
-	**OpenWrt** releases and LEDE since v17.01.**1** *do not require* upgrading the `ip-full` package version (normal installation by `opkg install ip-full` is enough).
-	
+    ```bash
+    # cd /tmp
+    # wget http://downloads.lede-project.org/snapshots/packages/x86_64/base/ip-full_4.4.0-10_x86_64.ipk
+    # opkg remove ip-full
+    # opkg install ip-full_4.4.0-10_x86_64.ipk
+    # rm ip-full_4.4.0-10_x86_64.ipk
+    ```
+
+    **Hint:** When copying the download URL from your browser, change `https` to `http` like the example above to allow downloading without having to install CA certificates.
+
+    **OpenWrt** releases and LEDE since v17.01.**1** *do not require* upgrading the `ip-full` package version (normal installation by `opkg install ip-full` is enough).
+
 2. Download the installer script script to /tmp on your router by running the following command:
-	
-	```
-	# curl -k -o /tmp/ip6neigh-setup.sh https://raw.githubusercontent.com/AndreBL/ip6neigh/master/ip6neigh-setup.sh
-	# chmod +x /tmp/ip6neigh-setup.sh
-	```
+
+    ```bash
+    # curl -k -o /tmp/ip6neigh-setup.sh https://raw.githubusercontent.com/AndreBL/ip6neigh/master/ip6neigh-setup.sh
+    # chmod +x /tmp/ip6neigh-setup.sh
+    ```
 
 3. Change directory to /tmp, and run `ip6neigh-setup.sh install`
 
-	
-	```
-	# ./ip6neigh-setup.sh install
-	Checking installer version...
-	The installer script is up to date.
 
-	Creating directory /usr/lib/ip6neigh/
-	Creating directory /usr/share/ip6neigh/
-	Downloading ip6neigh-setup.sh
-	Downloading lib/ip6addr_functions.sh
-	Downloading main/ip6neigh-svc.sh
-	Downloading main/ip6neigh.sh
-	Downloading etc/init.d/ip6neigh
-	Downloading etc/hotplug.d/iface/30-ip6neigh
-	Downloading etc/config/ip6neigh
-	
-	The downloaded example config file will be moved to /etc/config/ip6neigh.example.
-	Removing directory tree /tmp/ip6neigh/
+    ```bash
+    # ./ip6neigh-setup.sh install
+    Checking installer version...
+    The installer script is up to date.
 
-	--- The installation was successful. ---
-	
-	Run the following command if you want to download an offline OUI lookup database:
+    Creating directory /usr/lib/ip6neigh/
+    Creating directory /usr/share/ip6neigh/
+    Downloading ip6neigh-setup.sh
+    Downloading lib/ip6addr_functions.sh
+    Downloading main/ip6neigh-svc.sh
+    Downloading main/ip6neigh.sh
+    Downloading etc/init.d/ip6neigh
+    Downloading etc/hotplug.d/iface/30-ip6neigh
+    Downloading etc/config/ip6neigh
 
-		ip6neigh oui download
+    The downloaded example config file will be moved to /etc/config/ip6neigh.example.
+    Removing directory tree /tmp/ip6neigh/
 
-	Start ip6neigh with:
+    --- The installation was successful. ---
 
-		ip6neigh start
-	```
-   
-4. (Optional) Edit your current dhcp config file /etc/config/dhcp for adding predefined SLAAC hosts. 
+    Run the following command if you want to download an offline OUI lookup database:
+
+        ip6neigh oui download
+
+    Start ip6neigh with:
+
+        ip6neigh start
+    ```
+
+4. (Optional) Edit your current dhcp config file /etc/config/dhcp for adding predefined SLAAC hosts.
 
    Examples of predefined hosts at: [dhcp](etc/config/dhcp)
 
 5. Start ip6neigh...
 
-	manually with
+    manually with
 
-    ```
+    ```bash
     ip6neigh start
     ```
 
-	or on boot with
-	
-	```
-	ip6neigh enable
-	sync
-	reboot
-	```
+    or on boot with
+
+    ```bash
+    ip6neigh enable
+    sync
+    reboot
+    ```
 6. Use names instead of addresses for connecting to IPv6 hosts in your network.
 
 ### Uninstalling ip6neigh
 
 A copy of the installer script will be available in /usr/bin/ after installation. ip6neigh can be uninstalled by passing the `remove` parameter to the installer:
 
-```
+```bash
 # ip6neigh-setup remove
 Stopping ip6neigh...
 
@@ -138,28 +139,28 @@ The config file /etc/config/ip6neigh was kept in place for future use. Please re
 Finished uninstalling ip6neigh.
 ```
 
-## Accessing the Host file from the Web (LuCI) 
-It is possible to see the host file via the LuCI web interface by using luci-app-commands package. 
+## Accessing the Host file from the Web (LuCI)
+It is possible to see the host file via the LuCI web interface by using luci-app-commands package.
 
 1. Install by:
 
-	```
-	opkg update
-	opkg install luci-app-commands
-	```
+    ```bash
+    opkg update
+    opkg install luci-app-commands
+    ```
 
 2. Once installed, add the following to /etc/config/luci
 
-	```
-	#ip6neigh commands
-	config command
-        	option name 'IPv6 Neighbors'
-        	option command 'ip6neigh list active'
+    ```bash
+    #ip6neigh commands
+    config command
+            option name 'IPv6 Neighbors'
+            option command 'ip6neigh list active'
 
-	config command
-        	option name 'ip6neigh log'
-        	option command 'ip6neigh logread'
-	```
+    config command
+            option name 'ip6neigh log'
+            option command 'ip6neigh logread'
+    ```
 
 3. Now log into the LuCI web interface:
 
@@ -171,25 +172,25 @@ It is possible to see the host file via the LuCI web interface by using luci-app
 
 5. Or run from CLI
 
-	```
-	# ip6neigh list active
-	Chromecast                     fd32:197d:3022:1101:a677:33ff:fe52:45d2
-	Chromecast.GUA.lan             2804:7f5:f080:29a2:a677:33ff:fe52:45d2
-	Chromecast.LL.lan              fe80::a677:33ff:fe52:45d2
-	Chromecast.TMP.GUA.lan         2804:7f5:f080:29a2:1dc9:ae37:c1fb:6bec
-	Chromecast.TMP.lan             fd32:197d:3022:1101:1dc9:ae37:c1fb:6bec
-	Android-Andre                  fd32:197d:3022:1101:f6f5:24ff:fe9e:5ac7
-	Android-Andre.GUA.lan          2804:7f5:f080:29a2:f6f5:24ff:fe9e:5ac7
-	Android-Andre.LL.lan           fe80::f6f5:24ff:fe9e:5ac7
-	Android-Andre.TMP.GUA.lan      2804:7f5:f080:29a2:7094:bdf0:4911:6bf9
-	Android-Andre.TMP.lan          fd32:197d:3022:1101:7094:bdf0:4911:6bf9
-	Laptop                         fd32:197d:3022:1101:c4d7:e94:282d:60b1
-	Laptop.GUA.lan                 2804:7f5:f080:29a2:c4d7:e94:282d:60b1
-	Laptop.LL.lan                  fe80::c4d7:e94:282d:60b1
-	Laptop.TMP.GUA.lan             2804:7f5:f080:29a2:a840:ce89:7c91:93bd
-	Laptop.TMP.lan                 fd32:197d:3022:1101:4c62:38c9:247d:5b1f
+    ```bash
+    # ip6neigh list active
+    Chromecast                     fd32:197d:3022:1101:a677:33ff:fe52:45d2
+    Chromecast.GUA.lan             2804:7f5:f080:29a2:a677:33ff:fe52:45d2
+    Chromecast.LL.lan              fe80::a677:33ff:fe52:45d2
+    Chromecast.TMP.GUA.lan         2804:7f5:f080:29a2:1dc9:ae37:c1fb:6bec
+    Chromecast.TMP.lan             fd32:197d:3022:1101:1dc9:ae37:c1fb:6bec
+    Android-Andre                  fd32:197d:3022:1101:f6f5:24ff:fe9e:5ac7
+    Android-Andre.GUA.lan          2804:7f5:f080:29a2:f6f5:24ff:fe9e:5ac7
+    Android-Andre.LL.lan           fe80::f6f5:24ff:fe9e:5ac7
+    Android-Andre.TMP.GUA.lan      2804:7f5:f080:29a2:7094:bdf0:4911:6bf9
+    Android-Andre.TMP.lan          fd32:197d:3022:1101:7094:bdf0:4911:6bf9
+    Laptop                         fd32:197d:3022:1101:c4d7:e94:282d:60b1
+    Laptop.GUA.lan                 2804:7f5:f080:29a2:c4d7:e94:282d:60b1
+    Laptop.LL.lan                  fe80::c4d7:e94:282d:60b1
+    Laptop.TMP.GUA.lan             2804:7f5:f080:29a2:a840:ce89:7c91:93bd
+    Laptop.TMP.lan                 fd32:197d:3022:1101:4c62:38c9:247d:5b1f
 
-	```
+    ```
 
 ## Using DNS Labels
 `ip6neigh` uses DNS labels, which can be thought of as subdomains for the top level domain `lan`. Example DNS labels (in bold) that `ip6neigh` use are:
@@ -212,30 +213,30 @@ ip6neigh will discover new hosts on the LAN and assign them names. But you may w
 
 Predefined hosts are added to the `/etc/config/dhcp` file using the following:
 
-```
+```bash
 # Example 1: Devices that use standard EUI-64 interface identifiers (IIDs)
 # for all scopes:
 config host
-	option name		'Android-John'
-	#Copy the MAC address of the device.
-	option mac		'1a:41:8e:83:66:74'
-	option slaac	'1'
-	option iface	'lan'
+    option name		'Android-John'
+    #Copy the MAC address of the device.
+    option mac		'1a:41:8e:83:66:74'
+    option slaac	'1'
+    option iface	'lan'
 
 ```
 For Windows machines which do not use RFC 4862 EUI-64 SLAAC addressing (based on the MAC address):
 
-```
+```bash
 # Example 2: Windows machines or other hosts that do not use EUI-64 IIDs, but
 # use other static IIDs instead:
 config host
-	option name		'Laptop-Paul'
-	#Copy the MAC address of the device.
-	option mac		'2e:36:e7:85:d3:3b'
-	#Copy the interface identifier from the link-local address of
-	#of the device.
-	option slaac	'daa1:4554:747b:1f50'
-	option iface	'lan'
+    option name		'Laptop-Paul'
+    #Copy the MAC address of the device.
+    option mac		'2e:36:e7:85:d3:3b'
+    #Copy the interface identifier from the link-local address of
+    #of the device.
+    option slaac	'daa1:4554:747b:1f50'
+    option iface	'lan'
 
 ```
 Addresses with Stable (not Constant) Semantically Opaque IIDs (RFC 7217) cannot be currently added as predefined hosts (MacOS X 10.12, and iOS 10) if the prefix from the ISP is dynamic, as the host portion of the address (the IID) also changes when the prefix changes.
@@ -249,42 +250,66 @@ To accomplish this:
 
 1. Set up the DDNS config at the router to obtain the Host IPv6 address via an external script. Set this script to be the ip6neigh command that will echo the intended host's GUA:
 
-	```
-	/usr/bin/ip6neigh addr MyServer.GUA.lan 1
-	```
+    ```bash
+    /usr/bin/ip6neigh addr MyServer.GUA.lan 1
+    ```
 
 Regardless of prefix changes, `ip6neigh` will keep the IPv6 address up to date by name, and return the correct IPv6 address at the time of DDNS update.
 
 
 ### Configuration: Dynamic Firewall Rules
-When ISP changes the prefix, it can be challenging to update the firewall rules to permit external access. `ip6neigh` can also support the dynamic updating of firewall rules, based on DNS names (which remain constant, even though the prefix changes). 
+When ISP changes the prefix, it can be challenging to update the firewall rules to permit external access. `ip6neigh` can also support the dynamic updating of firewall rules, based on DNS names (which remain constant, even though the prefix changes).
 
 To setup Dynamic Firewall access rules:
 
 1. Set up predefined hosts (see above).
 2. Edit /etc/firewall.user and add lines:
 
-	```
-	 #ip6neigh
-	 touch /tmp/etc/firewall.ip6neigh
-	 ip6tables -N wan6_forwarding
-	 ip6tables -A forwarding_wan_rule -d 2000::/3 -j wan6_forwarding
-	```
+    ```bash
+     #ip6neigh
+     touch /tmp/etc/firewall.ip6neigh
+     ip6tables -N wan6_forwarding
+     ip6tables -A forwarding_wan_rule -d 2000::/3 -j wan6_forwarding
+    ```
 3. Edit /etc/config/firewall and right after
 
-	```
+    ```properties
     config include
-     	   option path '/etc/firewall.user'
-	```
-	add these two lines:
+            option path '/etc/firewall.user'
+    ```
+    add these two lines:
 
-	```
+    ```properties
     config include
             option path '/tmp/etc/firewall.ip6neigh'
-	```
+    ```
 4. Create your custom dynamic firewall script /root/ip6neigh_rules.sh using this template:
 
-	```
+```bash
+#!/bin/sh
+
+#Initialize the temp firewall script
+TMP_SCRIPT='/tmp/etc/firewall.ip6neigh'
+echo "ip6tables -F wan6_forwarding" > $TMP_SCRIPT
+
+#Create new rules for dynamic IPv6 addresses here. Example for accepting TCP connections on port 80 on a local server that identifies itself as 'Webserver' through DHCP.
+echo "ip6tables -A wan6_forwarding -d $(ip6neigh addr Webserver.GUA 1) -p tcp --dport 80 -j ACCEPT" >> $TMP_SCRIPT
+
+#Run the generated temp firewall script
+/bin/sh "$TMP_SCRIPT"
+```
+
+    ```
+    #!/bin/sh
+
+    #Initialize the temp firewall script
+    ```
+    config include
+            option path '/tmp/etc/firewall.ip6neigh'
+    ```
+4. Create your custom dynamic firewall script /root/ip6neigh_rules.sh using this template:
+
+    ```
     #!/bin/sh
 
     #Initialize the temp firewall script
@@ -296,21 +321,21 @@ To setup Dynamic Firewall access rules:
 
     #Run the generated temp firewall script
     /bin/sh "$TMP_SCRIPT"
-	```
+    ```
 5. Add your /root/ip6neigh_rules.sh script to ip6neigh config file /etc/config/ip6neigh
 
-	```
+    ```bash
     list fw_script '/root/ip6neigh_rules.sh'
-	```
+    ```
 6. Restart the OpenWrt firewall and ip6neigh:
 
-	```
+    ```bash
     /etc/init.d/firewall restart
     ip6neigh restart
     ```
 7. Wait a minute and check if the rules were successfully created:
 
-	```
+    ```bash
     root@OpenWrt:~# ip6tables -L wan6_forwarding
     Chain wan6_forwarding (1 references)
     target     prot opt source               destination
@@ -323,7 +348,7 @@ Included is a versatile tool called `ip6neigh` which controls most of the functi
 
 ### Help
 
-```
+```bash
 # ip6neigh
 ip6neigh Command Line Script
 
@@ -345,20 +370,21 @@ Command list:
 
 Typing shortcuts: rst lst sta dis act hst addr downl res who whos log
 ```
+
 `ip6neigh` options include:
 
 * `list    [ all | static | discovered | active | host HOSTNAME ]`
 With no extra argument: Shows all entries in the hosts file, with comments and blank line.
-	* `all` Displays all entries in hosts file without comments or blank lines. May be used for scripting purposes.
-	* `static` Displays the static entries in the host file.
-	* `discovered` Displays the dynamically discovered hosts in the host file.
-	* `active` Displays the entries that have REACHABLE or STALE NUD status in the router's neighbors table. Helps to find out which hosts have been recently online on the network.
-	* `host HOSTNAME` Displays the entries that are related to a single host device.
+    * `all` Displays all entries in hosts file without comments or blank lines. May be used for scripting purposes.
+    * `static` Displays the static entries in the host file.
+    * `discovered` Displays the dynamically discovered hosts in the host file.
+    * `active` Displays the entries that have REACHABLE or STALE NUD status in the router's neighbors table. Helps to find out which hosts have been recently online on the network.
+    * `host HOSTNAME` Displays the entries that are related to a single host device.
 *  `name { ADDRESS }`
-Displays the FQDN (Fully Qualified Domain Name) for the IPv6 address. Depending on the user configuration in `/etc/config/ip6neigh`, the top level domain will not appear if the host has no DNS label.  
+Displays the FQDN (Fully Qualified Domain Name) for the IPv6 address. Depending on the user configuration in `/etc/config/ip6neigh`, the top level domain will not appear if the host has no DNS label.
 * `address { NAME } [ 1 ]`
-Returns the IPv6 addresses for the FQDN. The top level domain name (e.g. 'lan') may be optionally omitted for convenience. Input examples: Laptop, Laptop.GUA, Laptop.GUA.lan, Laptop.TMP 
-	* This command has a clean output for external scripting, like supplying the address to DDNS Scripts or to a custom firewall script that generates rules for GUAs based on names because ISP is issuing a dynamic prefix.
+Returns the IPv6 addresses for the FQDN. The top level domain name (e.g. 'lan') may be optionally omitted for convenience. Input examples: Laptop, Laptop.GUA, Laptop.GUA.lan, Laptop.TMP
+    * This command has a clean output for external scripting, like supplying the address to DDNS Scripts or to a custom firewall script that generates rules for GUAs based on names because ISP is issuing a dynamic prefix.
 It is possible that hosts will have multiple temp addresses and they will have the same FQDN. If the extra argument '1' is supplied, limits the output to the first address associated with that FQDN.
 This command replaces `ip6neigh_ddns.sh`
 * `mac { NAME | ADDRESS }`
@@ -385,8 +411,8 @@ Displays version information.
 To install, run `ip6neigh oui download` command, which will install oui.gz for offline oui lookup.
 
 
-```
-# ip6neigh oui download 
+```bash
+# ip6neigh oui download
 Downloading Nmap MAC prefixes...
 Connecting to linuxnet.ca (24.222.55.20:80)
 oui-raw.txt          100% |***********************************************************************|   552k  0:00:00 ETA
@@ -404,7 +430,7 @@ Hosts which do not send their hostname (e.g. Unknown-9BA.LL.lan) will now have a
 
 `ip6neigh-svc.sh` should start up after step 6 above. You can check that it is running by typing
 
-```
+```bash
 # ps | grep ip6negh
 16727 root      1452 S    {ip6neigh-svc.sh} /bin/sh /usr/sbin/ip6neigh-svc.sh -s
 16773 root      1452 S    {ip6neigh-svc.sh} /bin/sh /usr/sbin/ip6neigh-svc.sh -s
@@ -413,26 +439,26 @@ Hosts which do not send their hostname (e.g. Unknown-9BA.LL.lan) will now have a
 
 You can also check the log file (enabled/disabled in `/etc/config/ip6negh`)
 
-```
+```bash
 # ip6neigh logread
 Fri Dec 23 23:44:31 UTC 2016 Starting ip6neigh script for physdev br-lan with domain lan
 Fri Dec 23 23:44:31 UTC 2016 Network does not have ULA prefix. Clearing label for GUAs.
 Fri Dec 23 23:44:31 UTC 2016 Generating predefined SLAAC addresses for router
 Fri Dec 23 23:44:41 UTC 2016 Added: alarm.LL.lan fe80::5048:e4ff:fe4d:a27d
 Fri Dec 23 23:44:54 UTC 2016 Added: alarm.TMP.lan 2001:db8:ebbd:4:3466:322a:649a:7172
-Fri Dec 23 23:44:54 UTC 2016 Probing other possible addresses for alarm: fe80::3466:322a:649a:7172 fe80::5048:e4ff:fe4d:a27d 
+Fri Dec 23 23:44:54 UTC 2016 Probing other possible addresses for alarm: fe80::3466:322a:649a:7172 fe80::5048:e4ff:fe4d:a27d
 ..
 Tue Dec 27 01:32:17 UTC 2016 Added: Unknown-01e0a4.LL.lan fe80::d69a:20ff:fe01:e0a4
 Tue Dec 27 01:32:19 UTC 2016 Added: Unknown-01e0a4.TMP.lan 2001:db8:ebbd:4:1d82:c1c3:c2a3:d46b
-Tue Dec 27 01:32:19 UTC 2016 Probing other possible addresses for Unknown-01e0a4: fe80::1d82:c1c3:c2a3:d46b fe80::d69a:20ff:fe01:e0a4 
+Tue Dec 27 01:32:19 UTC 2016 Probing other possible addresses for Unknown-01e0a4: fe80::1d82:c1c3:c2a3:d46b fe80::d69a:20ff:fe01:e0a4
 Tue Dec 27 01:32:20 UTC 2016 Added: hau 2001:db8:ebbd:4:d69a:20ff:fe01:e0a4
-Tue Dec 27 01:32:20 UTC 2016 Probing other possible addresses for hau: fe80::d69a:20ff:fe01:e0a4 
+Tue Dec 27 01:32:20 UTC 2016 Probing other possible addresses for hau: fe80::d69a:20ff:fe01:e0a4
 ```
-   
+
 To list the hostnames detected by **ip6neigh**.
 
-```
-# ip6neigh list 
+```bash
+# ip6neigh list
 #Predefined hosts
 Router                         fd32:197d:3022:1101::1
 Router.GUA.lan                 2804:7f5:f080:29a2::1
@@ -458,7 +484,7 @@ One only needs to install `ip-full` and `curl` packages. It has been tested on t
 
 Additional dependency for 'snooping' mode is `tcpdump`.
 
-In order to use the LuCI web interface, one must install `luci-app-commands`   
+In order to use the LuCI web interface, one must install `luci-app-commands`
 
 ## More Details
 
@@ -487,7 +513,7 @@ ip6neigh-svc.sh assumes that IPv6 subnets are /64 (which is what hosts should se
 
 ## Contributors
 
-The script is written by André Lange. Suggestions, and additions are welcome. Acknowledgements to Craig Miller for debugging and documentation. 
+The script is written by André Lange. Suggestions, and additions are welcome. Acknowledgements to Craig Miller for debugging and documentation.
 
 ## License
 

--- a/etc/init.d/ip6neigh
+++ b/etc/init.d/ip6neigh
@@ -27,7 +27,7 @@ errormsg() {
 
 start() {
 	pgrep -f "$SERVICE_NAME" >/dev/null && return 0
-	
+
 	[ -f "$SERVICE_SCRIPT" ] || errormsg "The main script file $SERVICE_SCRIPT is missing."
 
 	local snoop=$(uci get ip6neigh.config.dad_snoop 2>/dev/null)
@@ -46,7 +46,7 @@ start() {
 stop() {
 	local ppid
 	local cpid
-	
+
 	pgrep -f "$SERVICE_NAME" |
 		while IFS= read -r ppid
 		do

--- a/ip6neigh-setup.sh
+++ b/ip6neigh-setup.sh
@@ -14,7 +14,7 @@
 #
 #	by André Lange	Dec 2016
 
-readonly VERSION='1.7.0'
+readonly VERSION='2.0.0'
 
 readonly BIN_DIR="/usr/bin/"
 readonly SBIN_DIR="/usr/sbin/"
@@ -28,7 +28,7 @@ readonly CACHE_FILE="/tmp/ip6neigh.cache"
 
 readonly SERVICE_NAME="ip6neigh-svc.sh"
 
-readonly REPO="https://raw.githubusercontent.com/AndreBL/ip6neigh/master/"
+readonly REPO="https://raw.githubusercontent.com/Fail-Safe/ip6neigh/"
 
 #Installation list
 readonly inst_list="
@@ -113,13 +113,13 @@ install_line() {
 			mkdir -p "$dirname"
 			[ -d "$dirname" ] || errmsg "Could not create directory ${dirname}"
 		;;
-		
+
 		#Download file
 		"file")
 			local destname="$2"
 			local sourcename="$3"
 			local execflag="$4"
-			
+
 			echo "Downloading ${sourcename}"
 			download_file "$destname" "$sourcename"
 			if [ "$execflag" = "x" ]; then
@@ -141,7 +141,7 @@ uninstall_line() {
 				rmdir "$dirname" || flag_error
 			fi
 		;;
-		
+
 		#Remove directory tree
 		"tree")
 			local dirname="$2"
@@ -150,7 +150,7 @@ uninstall_line() {
 				rm -rf "$dirname" || flag_error
 			fi
 		;;
-		
+
 		#Remove files
 		"file")
 			shift
@@ -170,10 +170,10 @@ uninstall_line() {
 install() {
 	#Create temp dir
 	mkdir -p "$TEMP_DIR" || errormsg "Failed to create directory $TEMP_DIR"
-	
+
 	#Check curl
 	which curl >/dev/null || errormsg "ip6neigh requires package 'curl' to be installed before running this setup script. Please install 'curl' with:\n\nopkg update\nopkg install curl"
-	
+
 	#Check if the install list version match the repository
 	echo "Checking installer version..."
 	download_file "${TEMP_DIR}VERSION" "setup/VERSION"
@@ -181,7 +181,7 @@ install() {
 	local rem_version=$(cut -d '.' -f1-2 "${TEMP_DIR}VERSION")
 	[ "$loc_version" = "$rem_version" ] || errormsg "This installation script is out of date. Please visit https://github.com/AndreBL/ip6neigh and check if a new version of the installer is available for download."
 	echo "The installer script is up to date."
-	
+
 	#Check operating system
 	local OS
 	[ -f '/etc/openwrt_release' ] && OS='OpenWrt'
@@ -195,26 +195,26 @@ install() {
 				errormsg "ip6neigh requires package 'ip-full'. Please install 'ip-full' with:\n\nopkg update\nopkg install ip-full"
 			fi
 		;;
-		
+
 		'LEDE')
 			#Warning message
 			echo -e "\nWARNING: ip6neigh requires package 'ip-full' version 4.4.0-9 or above to run on LEDE. Using an older build will not work due to an issue with the 'ip monitor' command. Please visit https://github.com/AndreBL/ip6neigh for more info about installing or upgrading this package."
-			
+
 			#Check ip-full package
 			ip 2>&1 >/dev/null | grep -q 'monitor'
 			[ "$?" != 0 ] && errormsg "Missing package: ip-full"
 		;;
-		
+
 		*)
 			#Warning message
 			echo -e "\nWARNING: Operating system not supported. The installation will proceed anyway."
 		;;
 	esac
-	
+
 	#Check if already installed
 	[ -d "$LIB_DIR" ] && echo -e "\n The existing installation of ip6neigh will be overwritten."
 	check_running
-	
+
 	#Process install list
 	echo -e
 	local line
@@ -224,7 +224,7 @@ install() {
 		IFS=' '
 		[ -n "$line" ] && install_line $line
 	done
-	
+
 	#Check if UCI config file exists.
 	if [ -f "$CONFIG_FILE" ]; then
 		local confdest="${CONFIG_FILE}.example"
@@ -233,10 +233,10 @@ install() {
 	else
 		mv /tmp/ip6neigh/config "$CONFIG_FILE" || "Failed to move the configuration file"
 	fi
-	
+
 	#Remove temporary directory
 	uninstall_line tree "$TEMP_DIR"
-	
+
 	#Successful installation
 	echo -e "$SUCCESS_MSG"
 }
@@ -245,12 +245,12 @@ install() {
 uninstall() {
 	[ -d "$LIB_DIR" ] || [ -d "$SHARE_DIR" ] || errormsg "ip6neigh is not installed on this system."
 	check_running
-	
+
 	#Remove hosts and cache files
 	echo -e
 	uninstall_line file "$HOSTS_FILE"
 	uninstall_line file "$CACHE_FILE"
-	
+
 	#Process uninstall list
 	IFS=$'\n'
 	for line in $uninst_list;
@@ -258,12 +258,12 @@ uninstall() {
 		IFS=' '
 		[ -n "$line" ] && uninstall_line $line
 	done
-	
+
 	#Remove temporary directory
 	uninstall_line tree "$TEMP_DIR"
-	
+
 	[ -f "$CONFIG_FILE" ] && echo -e "\nThe config file $CONFIG_FILE was kept in place for future use. Please remove this file manually if you will not need it anymore."
-	
+
 	#Check if any error ocurred while removing files
 	if [ -z "$error" ]; then
 		echo -e "\nFinished uninstalling ip6neigh."
@@ -291,4 +291,3 @@ case "$1" in
 	"remove") uninstall;;
 	*) display_help "$0"
 esac
-

--- a/lib/ip6addr_functions.sh
+++ b/lib/ip6addr_functions.sh
@@ -30,23 +30,23 @@ _left_scan() {
 	local j c
 	local n=0
 	local x=1
-	
+
 	#Iterates through each character
 	for j in $(seq 0 $((${#1}-1)))
 	do
 		#Stops when '::' is found
 		[ "${1:$j:2}" = '::' ] && return $n
-		
+
 		#Current char
 		c="${1:$j:1}"
-	
+
 		case "$c" in
 			#Stop when reached the end
 			''|'.') return $n;;
-			
+
 			#Quibble advance
 			':') x=$(($x+1));;
-			
+
 			#Hex digit
 			*)
 				#Copy character to quibble
@@ -55,7 +55,7 @@ _left_scan() {
 			;;
 		esac
 	done
-	
+
 	return $n
 }
 
@@ -66,34 +66,34 @@ _right_scan() {
 	local n=8
 	local f="$2"
 	local ismapped=0
-	
+
 	#Iterates through each character in reverse order
 	for j in $(seq $((${#1}-1)) -1 0)
 	do
 		#Stops when '::' is found
 		[ "${1:$(($j-1)):2}" = '::' ] && break
-		
+
 		#Current char
 		c="${1:$j:1}"
-		
+
 		case "$c" in
 			#Stops when reached the end (start)
 			'') return 0;;
-			
+
 			#IPv4-mapped IPv6 address: skip one quibble and set flag
 			'.')
 				[ "$ismapped" = 0 ] && n=$(($n-1))
 				ismapped=1
 			;;
-			
+
 			#Quibble advance (backwards)
 			':')
 				n=$(($n-1))
-			
+
 				#Stop when reached the last quibble that was processed when scannin from left to right
 				[ "$n" = "$f" ] && return 0
 			;;
-			
+
 			#Hex digit
 			*)
 				#Copy character to quibble
@@ -101,25 +101,25 @@ _right_scan() {
 			;;
 		esac
 	done
-	
+
 	#Needs to process IPv4-mapped IPv6 address ?
 	[ "$ismapped" = 1 ] || return 0
 	local d1 d2 d3 d4
 	n=4
-	
+
 	#Iterates through each character in reverse order
 	for j in $(seq $((${#1}-1)) -1 0)
 	do
 		#Current char
 		c="${1:$j:1}"
-		
+
 		case "$c" in
 			#Octed advance (backwards)
 			'.') n=$(($n-1));;
-			
+
 			#End of last (first) octed
 			':') break;;
-			
+
 			#Decimal digit
 			*)
 				#Copy character to octet
@@ -127,11 +127,11 @@ _right_scan() {
 			;;
 		esac
 	done
-	
+
 	#Convert pairs of octets to 16-bit wide decimal numbers
 	eval q7=$((($d1<<8)+$d2))
 	eval q8=$((($d3<<8)+$d4))
-	
+
 	#Return signaling that q6 and q7 are decimal numbers
 	return 1
 }
@@ -154,11 +154,11 @@ expand_addr() {
 			fi
 		;;
 	esac
-		
+
 	#Save and reset the field separator
 	local OIFS="$IFS"
 	unset IFS
-	
+
 	#Process from left to right and then from right to left
 	local addr="$1"
 	local q1 q2 q3 q4 q5 q6 q7 q8
@@ -177,10 +177,10 @@ expand_addr() {
 		#IPv4-mapped IPv6 address. The last two quibbles come from decimal numbers.
 		printf '%x:%x:%x:%x:%x:%x:%x:%x\n' "0x0$q1" "0x0$q2" "0x0$q3" "0x0$q4" "0x0$q5" "0x0$q6" "$q7" "$q8"
 	fi
-	
+
 	#Restore the field separator
 	IFS="$OIFS"
-	
+
 	return 0
 }
 
@@ -201,7 +201,7 @@ compress_addr() {
 			return 0
 		;;
 	esac
-	
+
 	#Save and reset the field separator
 	local OIFS="$IFS"
 	unset IFS
@@ -225,23 +225,23 @@ compress_addr() {
 			;;
 		esac
 	done
-	
+
 	#All-zeros result ?
 	if [ "$result" = '::' ]; then echo '::';
 	else
 		#Remove the leading ':' if not '::'
 		[ "${result:0:2}" != '::' ] && result="${result:1}"
-		
+
 		#Remove the trailing ':' if not '::'
 		[ "${result:$((${#result}-2)):2}" != '::' ] && result="${result:0:$((${#result}-1))}"
-		
+
 		#Print result
 		echo "$result"
 	fi
-	
+
 	#Restore the field separator
 	IFS="$OIFS"
-	
+
 	return 0
 }
 
@@ -250,10 +250,10 @@ compress_addr() {
 addr_prefix64() {
 	#Do nothing with empty argument
 	[ -n "$1" ] || return 0
-	
+
 	#Expand the address
 	local expaddr=$(expand_addr "$1")
-	
+
 	#Cut the first four quibbles
 	echo "$expaddr" | cut -d ':' -f1-4
 
@@ -265,10 +265,10 @@ addr_prefix64() {
 addr_iid64() {
 	#Do nothing with empty argument
 	[ -n "$1" ] || return 0
-	
+
 	#Expand the address
 	local expaddr=$(expand_addr "$1")
-	
+
 	#Cut the last four quibbles
 	echo "$expaddr" | cut -d ':' -f5-8
 
@@ -284,21 +284,21 @@ join_prefix64_iid64() {
 	local prefix="$1"
 	local iid="$2"
 	local newaddr
-	
+
 	#Gets the prefix
-	[ "${prefix:$((${#prefix}-2)):2}" != '::' ] && prefix="${prefix}::" 
+	[ "${prefix:$((${#prefix}-2)):2}" != '::' ] && prefix="${prefix}::"
 	prefix=$(addr_prefix64 "$prefix")
-	
+
 	#Gets the IID
-	[ "${iid:0:2}" != '::' ] && iid="::${iid}" 
+	[ "${iid:0:2}" != '::' ] && iid="::${iid}"
 	iid=$(addr_iid64 "$iid")
-	
+
 	#Creates the new address by concatenation
 	newaddr="${prefix}:${iid}"
 
 	#Converts to compressed form
 	compress_addr "$newaddr"
-	
+
 	return 0
 }
 
@@ -310,13 +310,13 @@ gen_eui64() {
 	local q2="0x${mac:6:2}ff"
 	local q3="0xfe${mac:9:2}"
 	local q4="0x${mac:12:2}${mac:15:2}"
-	
+
 	#Flip U/L bit
 	q1=$(($q1 ^ 0x0200))
-		
+
 	#Print result
 	printf '%x:%x:%x:%x\n' "$q1" "$q2" "$q3" "$q4"
-	
+
 	return 0
 }
 
@@ -324,7 +324,7 @@ gen_eui64() {
 #1: ip6addr
 addr_is_eui64() {
 	echo "$1" | grep -q -E ':[^:]{0,2}ff:fe[^:]{2}:[^:]{1,4}$'
-	return "$?"	
+	return "$?"
 }
 
 #Generates a match string for an address with the same IID
@@ -335,7 +335,7 @@ gen_iid_match() {
 	case "$iid" in
 		#4 zeros
 		q0:0:0:0w)	comp='q:w';;
-		
+
 		#3 zeros
 		q0:0:0:*)	comp=$(echo "$iid" | sed "s/q0:0:0:/q:/")	;;
 		*:0:0:0w)	comp=$(echo "$iid" | sed "s/:0:0:0w/::w/")	;;
@@ -344,22 +344,22 @@ gen_iid_match() {
 		q0:0:*)		comp=$(echo "$iid" | sed "s/q0:0:/q:/")		;;
 		*:0:0:*)	comp=$(echo "$iid" | sed "s/:0:0:/::/")		;;
 		*:0:0w)		comp=$(echo "$iid" | sed "s/:0:0w/::w/")	;;
-		
+
 		#1 zero
 		q0:*)		comp=$(echo "$iid" | sed "s/q0:/q:/")		;;
 	esac
-	
+
 	if [ -n "$comp" ]; then
 		#Remove leading 'q' and 'w'
 		comp="${comp:1:$((${#comp}-2))}"
-		
+
 		#Match string
 		echo "[^ ]*(:${1}|:${comp})"
 	else
 		#Uncompressed only
 		echo "[^ ]*:$1"
 	fi
-	
+
 	return 0
 }
 

--- a/lib/test_libip6addr.sh
+++ b/lib/test_libip6addr.sh
@@ -15,7 +15,7 @@
 #	by Craig Miller		20 Feb 2017
 
 #
-#	NOTE: when running this off router, the library is _not_ POSIX compliant 
+#	NOTE: when running this off router, the library is _not_ POSIX compliant
 #		and will FAIL with 'dash'. On a desktop run the script using bash
 #
 #	bash test_libip6addr.sh -t
@@ -33,18 +33,18 @@ fi
 TEST_VERSION=1.1.2
 
 function usage {
-           echo " $0 - exercises ip6neigh ip6addr_functions library "
-	       echo "	e.g. $0 -t "
-	       echo "	-t                               Run Tests"
-	       echo "	-f <lib-function> <parameter>    Test individual function"
-	       echo "	e.g. $0 -f expand_addr ::1"
-	       echo "	"
-	       echo "	NOTE: when using from desktop call from bash"
-	       echo "	e.g. bash $0 -t"
-	       echo "	"
-	       echo " By Craig Miller - Version: $TEST_VERSION"
-	       exit 1
-           }
+		   echo " $0 - exercises ip6neigh ip6addr_functions library "
+		   echo "	e.g. $0 -t "
+		   echo "	-t                               Run Tests"
+		   echo "	-f <lib-function> <parameter>    Test individual function"
+		   echo "	e.g. $0 -f expand_addr ::1"
+		   echo "	"
+		   echo "	NOTE: when using from desktop call from bash"
+		   echo "	e.g. bash $0 -t"
+		   echo "	"
+		   echo " By Craig Miller - Version: $TEST_VERSION"
+		   exit 1
+		   }
 
 test() {
 
@@ -74,7 +74,7 @@ case "$1" in
 		# IPv4 Mapped addresses (will fail)
 		test ::ffff:192.0.2.128
 	;;
-	
+
 	# call a specific function with arguments - Example: -f expand_addr ::1
 	'-f')
 		shift 1

--- a/main/ip6neigh-svc.sh
+++ b/main/ip6neigh-svc.sh
@@ -47,14 +47,14 @@ for i in "$@" ; do
 			shift
 			;;
 		*)
-	                echo "ip6neigh Service Script v${SVC_VERSION}"
-	                echo -e
-	                echo "This script is intended to be run only by its init script."
-	                echo "If you want to start ip6neigh, type:"
-	                echo -e
-        	        echo "ip6neigh start"
-	                echo -e
-	                exit 1
+					echo "ip6neigh Service Script v${SVC_VERSION}"
+					echo -e
+					echo "This script is intended to be run only by its init script."
+					echo "If you want to start ip6neigh, type:"
+					echo -e
+					echo "ip6neigh start"
+					echo -e
+					exit 1
 			;;
 	esac
 done
@@ -143,23 +143,23 @@ if [ -z "$DOMAIN" ]; then DOMAIN="lan"; fi
 reload_hosts() {
 	#Check the pending flag
 	[ "$reload_pending" = 1 ] || return 0
-	
+
 	local now
 	local diff
-	
+
 	#Current time
 	now=$(date +%s)
 
 	#Difference from the last reload time in seconds
 	diff=$(($now - $reload_time))
-	
+
 	#Reloads if the difference is more than 5 seconds with reload pending
 	if [ "$diff" -ge 5 ]; then
 		reload_time="$now"
 		reload_pending=0
 		killall -1 dnsmasq
 	fi
-	
+
 	return 0
 }
 
@@ -192,7 +192,7 @@ add_cache() {
 	local mac="$1"
 	local name="$2"
 	local type="$3"
-	
+
 	#Write the name to the cache file.
 	logmsg "Creating type $type cache entry for $mac: ${name}"
 	echo "${mac} ${type} ${name}" >> "$CACHE_FILE"
@@ -220,7 +220,7 @@ rename() {
 	#Must save changes to another temp file and then move it over the main file.
 	sed "s/ ${oldname}/ ${newname}/g" "$HOSTS_FILE" > "$TEMP_FILE"
 	mv "$TEMP_FILE" "$HOSTS_FILE"
-	
+
 	#Deletes the old cached entry if dynamic.
 	grep -v "0. ${oldname}$" "$CACHE_FILE" > "$TEMP_FILE"
 	mv "$TEMP_FILE" "$CACHE_FILE"
@@ -234,21 +234,21 @@ rename() {
 remove_tmp_label() {
 	local addr="$1"
 	local name="$name"
-	
+
 	#Gets the interface identifier from the address
 	local iid=$(addr_iid64 "$addr")
-	
+
 	#IID match string
 	local im=$(gen_iid_match "$iid")
-	
+
 	#Get the list of addresses with the same IID from the same host
 	local match="^${im} ${name}\\${tmp_label}(\.|$)"
 	local list
 	list=$(grep -E "$match" "$HOSTS_FILE")
-	
+
 	#Return if nothing was found
 	[ "$?" = 0 ] || return 0
-	
+
 	#Create temp file without the matched lines
 	grep -v -E "$match" "$HOSTS_FILE" > "$TEMP_FILE"
 
@@ -257,7 +257,7 @@ remove_tmp_label() {
 		sed -e "s/${tmp_label}.${DOMAIN}//g" \
 			-e "s/${tmp_label}//g" \
 		>> "$TEMP_FILE"
-	
+
 	#Move the temp file over the main file
 	mv "$TEMP_FILE" "$HOSTS_FILE"
 
@@ -270,7 +270,7 @@ remove_tmp_label() {
 logmsg() {
 	#Check if logging is disabled
 	[ "$LOG" = "0" ] && return 0
-	
+
 	if [ "$LOG" = "1" ]; then
 		#Log to syslog
 		logger -t ip6neigh "[$LAN_DEV] $1"
@@ -278,24 +278,24 @@ logmsg() {
 		#Log to file
 		echo "$(date) [$LAN_DEV] $1" >> "$LOG"
 	fi
-	
+
 	#If -e argument was present, echo to stdout.
 	[ "$ECHO" = 1 ] && echo "$1"
-	
+
 	return 0
 }
 
 #Tries to guess if the supplied IPv6 address is non-temporary.
 is_other_static() {
 	local addr="$1"
-	
+
 	#Gets the interface identifier from the address
 	local iid=$(addr_iid64 "$addr")
-	
+
 	#Looks for a link-local address with the same IID and returns true if it finds one.
 	local lladdr=$(compress_addr "fe80:0:0:0:${iid}")
 	grep -q "^$lladdr " "$HOSTS_FILE" && return 0
-	
+
 	#Otherwise returns false
 	return 1
 }
@@ -304,13 +304,13 @@ is_other_static() {
 add_probe() {
 	#Compress the address
 	local addr=$(compress_addr "$1")
-	
+
 	#Do not add if the address already exist in some hosts file and unique flag was set on call.
 	[ "$2" -gt 0 ] && grep -q "^$addr[ ,"$'\t'"]" /tmp/hosts/* && return 0
-	
+
 	#Adds to the list
 	probe_list="${probe_list} ${addr}"
-	
+
 	return 0
 }
 
@@ -323,7 +323,7 @@ probe_addresses() {
 
 	#Initializes probe list
 	probe_list=""
-	
+
 	#Check if is configured for probing all the addresses from the same host
 	if [ "$PROBE_HOST" -gt 0 ]; then
 		#Get the address list for this host.
@@ -337,7 +337,7 @@ probe_addresses() {
 		done
 		IFS="$OIFS"
 	fi
-	
+
 	#Check if is configured for probing addresses with the same IID
 	local base_iid=""
 	if [ "$PROBE_IID" -gt 0 ]; then
@@ -369,17 +369,17 @@ probe_addresses() {
 			fi
 		fi
 	fi
-	
 
-	
+
+
 	#Exit if there is nothing to probe.
 	[ -n "$probe_list" ] || return 0
-	
+
 	#Removes leading space from the list
 	probe_list="${probe_list:1}"
-	
+
 	logmsg "Probing other possible addresses for ${name}: ${probe_list}"
-	
+
 	#Ping each address once.
 	local addr
 	local OIFS="$IFS"
@@ -390,7 +390,7 @@ probe_addresses() {
 		fi
 	done
 	IFS="$OIFS"
-	
+
 	#Clears the probe list.
 	probe_list=""
 
@@ -407,7 +407,7 @@ dhcp_name() {
 	if [ "$DHCPV6_NAMES" -gt 0 ]; then
 		match=$(echo "$mac" | tr -d ':')
 		name=$(grep -m 1 -E "^# ${LAN_DEV} (00010001.{8}|00030001)${match} [^ ]* [^-]" /tmp/hosts/odhcpd | cut -d ' ' -f5)
-		
+
 		#Success getting name from DHCPv6.
 		if [ -n "$name" ]; then
 			add_cache "$mac" "$name" '06'
@@ -419,7 +419,7 @@ dhcp_name() {
 	#If couldn't find a match in DHCPv6 leases then look into the DHCPv4 leases file.
 	if [ "$DHCPV4_NAMES" -gt 0 ]; then
 		name=$(grep -m 1 -E " $mac [^ ]{7,15} ([^*])" $LEASE_FILE | cut -d ' ' -f4)
-		
+
 		#Success getting name from DHCPv4.
 		if [ -n "$name" ]; then
 			add_cache "$mac" "$name" '04'
@@ -427,7 +427,7 @@ dhcp_name() {
 			return 0
 		fi
 	fi
-	
+
 	#Failed. Return error.
 	return 1
 }
@@ -442,7 +442,7 @@ is_dhcpv6_addr() {
 		"$wula_man_hint":*) return 0;;
 		"$gua_man_hint":*) return 0;;
 	esac
-	
+
 	return 1
 }
 
@@ -451,21 +451,21 @@ oui_name() {
 	#Get MAC and separates OUI part.
 	local mac="$1"
 	local oui="${mac:0:6}"
-	
+
 	#Check if the MAC is locally administered.
 	if [ "$((0x${oui:0:2} & 0x02))" != 0 ]; then
 		#Returns LocalAdmin as name and success.
 		echo 'LocalAdmin'
 		return 0
 	fi
-	
+
 	#Fails here if OUI file does not exist.
 	[ -f "$OUI_FILE" ] || return 1
 
 	#Searches for the OUI in the database.
 	local reg=$(gunzip -c "$OUI_FILE" | grep -m 1 "^$oui")
 	local name="${reg:6}"
-	
+
 	#Check if found.
 	if [ -n "$name" ]; then
 		#Returns the manufacturer name and success code.
@@ -481,7 +481,7 @@ oui_name() {
 manuf_name() {
 	local mac="$1"
 	local name
-	
+
 	#Get info from the MAC.
 	local upmac=$(echo "$mac" | tr -d ':' | awk '{print toupper($0)}')
 	local nicid="${upmac:9}"
@@ -501,7 +501,7 @@ manuf_name() {
 			logmsg "Too many name conflicts for ${name}. Giving up."
 			return 2
 		fi
-		
+
 		#Generate new name.
 		code=$(printf %x $count)
 		code=$(echo "${mac}${code}" | tr -d ':' | md5sum)
@@ -509,10 +509,10 @@ manuf_name() {
 		true $(( code++ ))
 		logmsg "Name conflict for ${mac}. Trying ${name}"
 	done
-	
+
 	#Writes entry to the cache with type 01.
 	add_cache "$mac" "$name" '01'
- 	
+
 	#Returns the newly created name.
 	echo "$name"
 	return 0
@@ -523,14 +523,14 @@ create_name() {
 	local mac="$1"
 	local acceptmanuf="$2"
 	local name
-	
+
 	#Look for a name in the cache file.
 	local lease
 	lease=$(grep -m 1 "^${mac} " "$CACHE_FILE")
 	if [ "$?" = 0 ]; then
 		#Get type.
 		local type=$(echo "$lease" | cut -d ' ' -f2)
-		
+
 		#Check if the cached entry can be used in this call.
 		if [ "$acceptmanuf" -gt 0 ] || [ "$type" != '01' ]; then
 			#Get name and use it.
@@ -555,7 +555,7 @@ create_name() {
 			return 0
 		fi
 	fi
-	
+
 	#Returns fail
 	return 1
 }
@@ -564,20 +564,20 @@ create_name() {
 get_name() {
 	local addr="$1"
 	local matched
-	
+
 	#Check if the address already exists
 	matched=$(grep -m 1 "^$addr[ ,"$'\t'"]" /tmp/hosts/*)
-	
+
 	#Address is new? (not found)
 	[ "$?" != 0 ] && return 2
-	
+
 	#Check what kind of name it has
 	local fqdn=$(echo "$matched" | tr $'\t' ' ' | cut -d ' ' -f2)
 	local name=$(echo "$fqdn" | cut -d '.' -f1)
-	
+
 	#Outputs the name
 	echo "$name"
-	
+
 	#Manufacturer name?
 	grep -q "01 ${name}$" "$CACHE_FILE" && return 1
 
@@ -590,12 +590,12 @@ process() {
 	local addr
 	local mac="$3"
 	local status
-	
+
 	#Get the address and translate delete events to FAILED.
 	if [ "$1" = 'delete' ]; then
 		addr="$2"
 		status="FAILED"
-	else 
+	else
 		addr="$1"
 		for status; do true; done
 	fi
@@ -615,31 +615,31 @@ process() {
 		"FAILED")
 			#Get the line number that divides the two sections of the hosts file
 			local ln=$(grep -n '^#Discovered' "$HOSTS_FILE" | cut -d ':' -f1)
-			
+
 			#If this is not an address from the "discovered" section, do nothing.
 			awk "NR>${ln}"' {printf "%s\n",$1}' "$HOSTS_FILE" |
 				grep -q "^${addr}$"
 			[ "$?" = 0 ] || return 0
-			
+
 			#Remove the address.
 			remove "$addr"
-					
+
 			#Check if it was the last entry with that name.
 			if ! grep -q -E " ${currname}(\.|$)" "$HOSTS_FILE" ; then
 				#Remove from cache.
 				remove_cache "${currname}"
 			fi
-		
+
 			return 0
 		;;
-		
+
 		#Neighbor is reachable or stale. Must be processed.
 		"REACHABLE"|"STALE"|"PERMANENT")
 			#Decide what to do based on type.
 			case "$type" in
 				#Address already has a stable name. Nothing to be done.
 				0) return 0;;
-				
+
 				#Address is using manufacturer name.
 				1)
 					#Create name for address, not allowing to generate from manufacturer again.
@@ -652,7 +652,7 @@ process() {
 
 					return 0
 				;;
-				
+
 				#Address is new.
 				2)
 					#Create name for address, allowing to generate from manufacturer.
@@ -663,32 +663,32 @@ process() {
 					fi
 				;;
 			esac
-			
+
 			#Get the /64 prefix
 			local prefix=$(addr_prefix64 "$addr")
-	
+
 			#Check address scope and assign proper labels.
 			local suffix=""
 			local scope
 			if [ "$prefix" = 'fe80:0:0:0' ]; then
 				#Is link-local. Append corresponding label.
 				suffix="${lla_label}"
-				
+
 				#Sets scope ID to LLA
 				scope=0
-				
+
 				#Remove the TMP label from the addresses from the same host that have the same IID
 				[ -n "$tmp_label" ] && remove_tmp_label "$addr" "$name"
 			elif [ "$prefix" = "$ula_prefix" ] || [ -z "$urt_label" -a "${addr:0:2}" = "fd" ] ; then
 				#Is ULA. Append corresponding label.
 				suffix="${ula_label}"
-				
+
 				#Sets scope ID to ULA
 				scope=1
 			elif [ "$prefix" = "$wula_prefix" ]; then
 				#Is WAN side ULA. Append corresponding label.
 				suffix="${wula_label}"
-				
+
 				#Sets scope ID to WULA
 				scope=2
 			elif [ "$prefix" = "$gua_prefix" ] || [ -z "$urt_label" ]; then
@@ -700,11 +700,11 @@ process() {
 			else
 				#The address uses a prefix that is not routed to this LAN.
 				suffix="$urt_label"
-				
+
 				#Sets scope ID to unrouted.
 				scope=4
 			fi
-			
+
 			#Check if it needs some secondary label
 			if [ "$scope" -ge 1 ] && [ "$scope" -le 3 ]; then
 				#Managed address ?
@@ -723,26 +723,26 @@ process() {
 				#Names with labels get FQDN
 				hostsname="${name}${suffix}.${DOMAIN}"
 			else
-				#Names without labels 
+				#Names without labels
 				hostsname="${name}"
 			fi
-			
+
 			#Adds entry to hosts file
 			add "$hostsname" "$addr"
-			
+
 			#Checks if this host must have nud perm for all addresses.
 			if grep -q "30 ${name}$" "$CACHE_FILE"; then
 				ip -6 neigh replace "$addr" lladdr "$mac" dev "$LAN_DEV" nud perm
 				logmsg "Changed NUD state to permanent for ${hostsname}."
 			fi
-			
+
 			#Probe other addresses related to this one if not unrouted and the global switch is enabled.
 			if [ "$AUTO_PROBE" = 1 ] && [ "$scope" != 4 ]; then
 				probe_addresses "$name" "$addr" "$mac" "$scope"
 			fi
 		;;
 	esac
-	
+
 	return 0
 }
 
@@ -755,7 +755,7 @@ add_static() {
 	local mac="$5"
 	local perm="$6"
 	local suffix=""
-	
+
 	#Builds the address if needed.
 	local addr
 	if [ -n "$iid" ]; then
@@ -771,20 +771,20 @@ add_static() {
 
 		#ULA
 		1) if [ -n "${ula_label}" ]; then suffix="${ula_label}.${DOMAIN}"; fi;;
-		
+
 		#WULA
 		2) if [ -n "${wula_label}" ]; then suffix="${wula_label}.${DOMAIN}"; fi;;
-		
+
 		#GUA
 		3) if [ -n "${gua_label}" ]; then suffix="${gua_label}.${DOMAIN}"; fi;;
 	esac
-	
+
 	#Writes the entry to the file
 	echo "${addr} ${name}${suffix}" >> "$HOSTS_FILE"
-	
+
 	#Adds a permanent entry in the neighbors table if requested to do so.
 	[ "$perm" -gt 0 ] && ip -6 neigh replace "$addr" lladdr "$mac" dev "$LAN_DEV" nud perm
-	
+
 	return 0
 }
 
@@ -796,7 +796,7 @@ config_host() {
 	config_get name "$1" name
 	config_get mac "$1" mac
 	config_get iface "$1" iface
-	
+
 	#Ignore entry if the minimum required options are missing.
 	if [ -z "$name" ] || [ -z "$mac" ] || [ -z "$iface" ] ; then
 		logmsg "Host entry will be ignored because either the name, the mac or the iface option is missing."
@@ -807,8 +807,8 @@ config_host() {
 	if [ "$iface" != "$LAN_IFACE" ] ; then
 		logmsg "Host entry $name will be ignored because it is connected to interface $iface."
 		return 0;
-	fi 
-	
+	fi
+
 	#Load more options
 	local ip
 	local duid
@@ -818,10 +818,10 @@ config_host() {
 	config_get duid "$1" duid
 	config_get slaac "$1" slaac "0"
 	config_get perm "$1" perm 0
-	
+
 	#Converts user typed MAC to lowercase
 	mac=$(echo "$mac" | awk '{print tolower($0)}')
-	
+
 	#Populate cache with name, depending on supplied options.
 	if [ "$LOAD_STATIC" -gt 0 ] && [ "$slaac" != "0" ]; then
 		#Decides the first digit of type value.
@@ -844,7 +844,7 @@ config_host() {
 	if [ -z "$slaac" ] || [ "$slaac" = "0" ]; then
 		return 0
 	fi
-	
+
 	#Checks if requested to permanent entries to neighbors table
 	if [ "$perm" -gt 0 ]; then
 		#Adds permanent entry to IPv4 neighbors table if and IPv4 address was specified.
@@ -913,7 +913,7 @@ load_neigh() {
 main_service() {
 	#Startup message
 	logmsg "Starting ip6neigh main service v${SVC_VERSION} for physdev $LAN_DEV with domain $DOMAIN"
-	
+
 	#Var initialization
 	reload_time=0
 	reload_pending=1
@@ -932,7 +932,7 @@ main_service() {
 	ula_prefix=$(addr_prefix64 "$ula_address")
 	wula_prefix=$(addr_prefix64 "$wula_address")
 	gua_prefix=$(addr_prefix64 "$gua_address")
-	
+
 	#Separate the first 32-bit from the IID of the router's addresses do match against managed addresses.
 	ula_man_hint=$(addr_iid64 "$ula_address" | cut -d ':' -f1-2)
 	wula_man_hint=$(addr_iid64 "$wula_address" | cut -d ':' -f1-2)
@@ -992,7 +992,7 @@ main_service() {
 	if [ -n "$tmp_label" ]; then tmp_label=".${tmp_label}" ; fi
 	if [ -n "$man_label" ]; then man_label=".${man_label}" ; fi
 	if [ -n "$urt_label" ]; then urt_label=".${urt_label}" ; fi
-		
+
 	#Clears the cache file
 	> "$CACHE_FILE"
 
@@ -1007,7 +1007,7 @@ main_service() {
 		[ "$(($FLUSH & 2))" -gt 0 ] && FLUSH_STALE=1
 		[ "$(($FLUSH & 4))" -gt 0 ] && FLUSH_REACH=1
 		logmsg "Flushing the neighbors table. Flags: PERM=$FLUSH_PERM STALE=$FLUSH_STALE REACH=$FLUSH_REACH"
-		
+
 		#Flushes the corresponding neighbors
 		[ "$FLUSH_PERM" = 1 ] && ip -6 neigh flush dev "$LAN_DEV" nud perm
 		[ "$FLUSH_STALE" = 1 ] && ip -6 neigh flush dev "$LAN_DEV" nud stale
@@ -1036,7 +1036,7 @@ main_service() {
 
 	#Send signal to dnsmasq to reload hosts files.
 	reload_hosts
-	
+
 
 	#Pings "all nodes" multicast address with source addresses from various scopes to speedup discovery.
 	ping6 -q -W 1 -c 3 -s 0 -I "$LAN_DEV" ff02::1 >/dev/null 2>/dev/null
@@ -1050,7 +1050,7 @@ main_service() {
 	LOAD_STALE=1
 	AUTO_PROBE=1
 	load_neigh
-	
+
 	#If some auto-probe is enable, run one more round for detecting the new neighbors after ping6.
 	if [ "$PROBE_EUI64" -gt 0 ] || [ "$PROBE_IID" -gt 0 ]; then
 		logmsg "Syncing the hosts file with the neighbors table... Round #2"
@@ -1058,7 +1058,7 @@ main_service() {
 		AUTO_PROBE=0
 		load_neigh
 	fi
-		
+
 	#Check if there are custom scripts to be runned.
 	if [ -n "$FW_SCRIPT" ]; then
 		for script in $FW_SCRIPT; do
@@ -1071,13 +1071,13 @@ main_service() {
 			fi
 		done
 	fi
-	
+
 	#Check if allowed to setup radvd
 	if [ "$SETUP_RADVD" -gt 0 ] && [ -n "$gua_prefix" ] && which radvd >/dev/null; then
 		#Store the current prefix in the temp file
 		local new_prefix="${gua_prefix}::/64"
 		echo "$new_prefix" > "/tmp/etc/prefix.${LAN_DEV}"
-				
+
 		#Persistent file for storing the old prefix
 		local file='/etc/deprecate.prefix'
 
@@ -1098,12 +1098,12 @@ main_service() {
 			uci set radvd.deprecate.ignore=1
 			uci commit radvd
 		fi
-		
+
 		#Restart radvd
 		/etc/init.d/radvd enabled && /etc/init.d/radvd restart
 	fi
-	
-	 
+
+
 	#Infinite main loop. Keeps monitoring changes in IPv6 neighbor's reachability status and call process() routine.
 	logmsg "Monitoring changes in the neighbor's table..."
 	LOAD_STALE=0
@@ -1115,7 +1115,7 @@ main_service() {
 			process $line
 			reload_hosts
 		done
-	
+
 	logmsg "Terminating the main service"
 	return 0
 }
@@ -1132,35 +1132,35 @@ snooping_service() {
 
 	local line
 	local addr
-	
+
 	#If the LAN iface is bridged, disable IGMP snooping on the bridge.
 	local mcsnoop="/sys/class/net/${LAN_DEV}/bridge/multicast_snooping"
 	[ -f "$mcsnoop" ] && echo 0 > "$mcsnoop"
-	
+
 	#Enables the 'allmulticast' flag on the interface
 	ip link set "$LAN_DEV" allmulticast on
-	
+
 	#Infinite loop. Keeps listening to DAD NS packets and pings the captured addresses.
 	tcpdump -q -l -n -p -i "$LAN_DEV" 'src :: && icmp6 && ip6[40] == 135' 2>/dev/null |
 		while IFS= read -r line
 		do
 			#Get the address from the line
 			addr=$(echo $line | awk '{print substr($11,1,length($11)-1);}')
-			
+
 			#Ignore blank address
 			[ -n "$addr" ] || continue
-			
+
 			#Check if the address already exists in any hosts file
 			if [ "$PROBE_HOST" != 1 ] && grep -q "^$addr[ ,"$'\t'"]" /tmp/hosts/* ; then
 				continue
 			fi
-				
+
 			#Ping the address to trigger a NS message from the router
 			sleep 1
 			logmsg "Probing $addr after snooping a DAD NS packet from it"
 			ping6 -q -W 1 -c 1 -s 0 -I "$LAN_DEV" "$addr" >/dev/null 2>/dev/null
 		done
-	
+
 	logmsg "Terminating the snooping service"
 	return 0
 }

--- a/main/ip6neigh.sh
+++ b/main/ip6neigh.sh
@@ -137,10 +137,10 @@ list_hosts() {
 
 list_hosts_iface() {
 	check_files
-	
+
 	#Get the line number that divides the two sections of the hosts file
 	local ln=$(grep -n '^#Discovered' "$HOSTS_FILE" | cut -d ':' -f1)
-	
+
 	case "$1" in
 		#All hosts without comments or blank lines
 		all)
@@ -179,7 +179,7 @@ list_hosts_iface() {
 
 				#Prints the temp file.
 				sort /tmp/ip6neigh.lst
-				rm /tmp/ip6neigh.lst			
+				rm /tmp/ip6neigh.lst
 		;;
 		#Addresses from a specific host
 		host|hst)
@@ -205,10 +205,10 @@ list_hosts_iface() {
 #Format FQDN for grep.
 format_fqdn() {
 	load_config
-	
+
 	#Check FQDN
 	local ffqdn="$2"
-	
+
 	case "$ffqdn" in
 		#Ends with .lan ?
 		?*".$DOMAIN")
@@ -227,37 +227,37 @@ format_fqdn() {
 			ffqdn="${2}.${DOMAIN}"
 		;;
 	esac
-	
+
 	#Escape dots
 	ffqdn=$(echo "$ffqdn" | sed 's/\./\\\./g')
-	
+
 	#Returns the formatted FQDN.
 	eval "$1='$ffqdn'"
 }
 
 #Displays the addresses for the supplied name
 show_address() {
-        load_config
-        check_running
+		load_config
+		check_running
 
-        for LAN_IFACE in $LAN_IFACES ; do
-                HOSTS_FILE="/tmp/hosts/ip6neigh.$LAN_IFACE"
-                CACHE_FILE="/tmp/ip6neigh.$LAN_IFACE.cache"
+		for LAN_IFACE in $LAN_IFACES ; do
+				HOSTS_FILE="/tmp/hosts/ip6neigh.$LAN_IFACE"
+				CACHE_FILE="/tmp/ip6neigh.$LAN_IFACE.cache"
 
-                network_get_physdev LAN_DEV "$LAN_IFACE"
-                show_address_iface "$1" "$2"
-        done
+				network_get_physdev LAN_DEV "$LAN_IFACE"
+				show_address_iface "$1" "$2"
+		done
 }
 
 show_address_iface() {
 	check_files
-	
+
 	#Check FQDN
 	local name
 	format_fqdn name "$1"
-	
+
 	case "$2" in
-		#Any number of addresses 
+		#Any number of addresses
 		'')
 			grep -i " ${name}$" "$HOSTS_FILE" |
 				cut -d ' ' -f1
@@ -274,21 +274,21 @@ show_address_iface() {
 
 #Displays the name for the IPv6 or MAC address
 show_name() {
-        load_config
-        check_running
+		load_config
+		check_running
 
-        for LAN_IFACE in $LAN_IFACES ; do
-                HOSTS_FILE="/tmp/hosts/ip6neigh.$LAN_IFACE"
-                CACHE_FILE="/tmp/ip6neigh.$LAN_IFACE.cache"
+		for LAN_IFACE in $LAN_IFACES ; do
+				HOSTS_FILE="/tmp/hosts/ip6neigh.$LAN_IFACE"
+				CACHE_FILE="/tmp/ip6neigh.$LAN_IFACE.cache"
 
-                network_get_physdev LAN_DEV "$LAN_IFACE"
-                show_name_iface "$1"
-        done
+				network_get_physdev LAN_DEV "$LAN_IFACE"
+				show_name_iface "$1"
+		done
 }
 
 show_name_iface() {
 	check_files
-	
+
 	#Compress the address
 	local addr=$(reformat_addr "$1")
 
@@ -298,22 +298,22 @@ show_name_iface() {
 
 #Display the MAC address for a simple name, FQDN or IPv6 address.
 show_mac() {
-        load_config
-        check_running
+		load_config
+		check_running
 
-        for LAN_IFACE in $LAN_IFACES ; do
-                HOSTS_FILE="/tmp/hosts/ip6neigh.$LAN_IFACE"
-                CACHE_FILE="/tmp/ip6neigh.$LAN_IFACE.cache"
+		for LAN_IFACE in $LAN_IFACES ; do
+				HOSTS_FILE="/tmp/hosts/ip6neigh.$LAN_IFACE"
+				CACHE_FILE="/tmp/ip6neigh.$LAN_IFACE.cache"
 
-                network_get_physdev LAN_DEV "$LAN_IFACE"
-                show_mac_iface "$1"
-        done
+				network_get_physdev LAN_DEV "$LAN_IFACE"
+				show_mac_iface "$1"
+		done
 }
 
 show_mac_iface() {
 	check_files
 	local name
-	
+
 	#Check if it's address or name.
 	case "$1" in
 		*':'*)
@@ -332,9 +332,9 @@ show_mac_iface() {
 			name=$(echo "$1" | cut -d '.' -f1)
 		;;
 	esac
-	
+
 	[ -n "$name" ] || exit 3
-	
+
 	#Get the MAC address from the cache file.
 	grep -m 1 -i " ${name}$" "$CACHE_FILE" |
 		cut -d ' ' -f1
@@ -342,21 +342,21 @@ show_mac_iface() {
 
 #Resolves name to address or address to name.
 resolve_cmd() {
-        load_config
-        check_running
+		load_config
+		check_running
 
-        for LAN_IFACE in $LAN_IFACES ; do
-                HOSTS_FILE="/tmp/hosts/ip6neigh.$LAN_IFACE"
-                CACHE_FILE="/tmp/ip6neigh.$LAN_IFACE.cache"
+		for LAN_IFACE in $LAN_IFACES ; do
+				HOSTS_FILE="/tmp/hosts/ip6neigh.$LAN_IFACE"
+				CACHE_FILE="/tmp/ip6neigh.$LAN_IFACE.cache"
 
-                network_get_physdev LAN_DEV "$LAN_IFACE"
-                resolve_cmd_iface "$1" "$2"
-        done
+				network_get_physdev LAN_DEV "$LAN_IFACE"
+				resolve_cmd_iface "$1" "$2"
+		done
 }
 
 resolve_cmd_iface() {
 	check_files
-	
+
 	#Check if it's address or name.
 	case "$1" in
 		*':'*)
@@ -380,27 +380,27 @@ resolve_cmd_iface() {
 
 #Displays the simple name (no FQDN) for the address or all addresses for the simple name.
 whois_this() {
-        load_config
-        check_running
+		load_config
+		check_running
 
-        for LAN_IFACE in $LAN_IFACES ; do
-                HOSTS_FILE="/tmp/hosts/ip6neigh.$LAN_IFACE"
-                CACHE_FILE="/tmp/ip6neigh.$LAN_IFACE.cache"
+		for LAN_IFACE in $LAN_IFACES ; do
+				HOSTS_FILE="/tmp/hosts/ip6neigh.$LAN_IFACE"
+				CACHE_FILE="/tmp/ip6neigh.$LAN_IFACE.cache"
 
-                network_get_physdev LAN_DEV "$LAN_IFACE"
-                whois_this_iface "$1"
-        done
+				network_get_physdev LAN_DEV "$LAN_IFACE"
+				whois_this_iface "$1"
+		done
 }
 
 whois_this_iface() {
 	check_files
-	
+
 	local host
 	local names
 	local mac
 	local manuf
 	local reg
-	
+
 	#Check if it's an address.
 	case "$1" in
 		#Check if it's a MAC address.
@@ -421,13 +421,13 @@ whois_this_iface() {
 				cut -d '.' -f1
 			)
 			[ -n "$host" ] || exit 3
-			
+
 			mac=$(
 				grep -m 1 -i " $host" "$CACHE_FILE" |
 				cut -d ' ' -f1
 			)
 		;;
-		#Host		
+		#Host
 		*)
 			host=$(echo "$1" | cut -d '.' -f1)
 			reg=$(grep -m 1 -i " ${host}$" "$CACHE_FILE")
@@ -436,20 +436,20 @@ whois_this_iface() {
 			host=$(echo "$reg" | cut -d ' ' -f3)
 		;;
 	esac
-	
+
 	#Get the OUI info.
 	if [ -n "$mac" ]; then
 		oui_name manuf "$mac"
 	fi
-	
+
 	#Exit if no info was found.
 	[ -z "$host" ] && [ -z "$manuf" ] && exit 3
-	
+
 	#Displays the available info.
 	[ -n "$host" ] && echo "Hostname: $host"
 	echo "MAC: $mac"
 	[ -n "$manuf" ] && echo "OUI: $manuf"
-	
+
 	#Displays a list of names that belong to this host.
 	names=$(
 		grep -i -E " ${host}(\.|$)" "$HOSTS_FILE" |
@@ -458,7 +458,7 @@ whois_this_iface() {
 		uniq
 	)
 	[ -n "$names" ] && echo 'FQDN:' $names
-	
+
 	return 0
 }
 
@@ -466,7 +466,7 @@ whois_this_iface() {
 oui_download() {
 	echo "Downloading Nmap MAC prefixes..."
 	oui_url='https://standards-oui.ieee.org/oui/oui.txt'
-    curl -# -S -f -k -o '/tmp/oui-raw.txt' $oui_url || exit 2
+	curl -# -S -f -k -o '/tmp/oui-raw.txt' $oui_url || exit 2
 
 	echo -e "\nApplying filters..."
 
@@ -495,32 +495,32 @@ oui_name() {
 	#Get MAC and separates OUI part.
 	local mac=$(echo "$2" | tr -d ':')
 	local oui="${mac:0:6}"
-	
+
 	#Check if this is the broadcast MAC
 	if [ "$mac" = 'ffffffffffff' ]; then
 		eval "$1='Broadcast address'"
 		return 0
 	fi
-	
+
 	#Check if the MAC is a multicast address.
 	if [ "$((0x${oui:0:2} & 0x01))" != 0 ]; then
 		eval "$1='Multicast address'"
 		return 0
 	fi
-	
+
 	#Check if the MAC is locally administered.
 	if [ "$((0x${oui:0:2} & 0x02))" != 0 ]; then
 		eval "$1='Locally administered'"
 		return 0
 	fi
-	
+
 	#Fails here if OUI file does not exist.
 	[ -f "$OUI_FILE" ] || return 1
 
 	#Searches for the OUI in the database.
 	local reg=$(gunzip -c "$OUI_FILE" | grep -i -m 1 "^$oui")
 	local oname="${reg:6}"
-	
+
 	#Check if found.
 	if [ -n "$oname" ]; then
 		#Returns the manufacturer name and success code.
@@ -550,10 +550,10 @@ oui_cmd() {
 	case "$1" in
 		#Download OUI database
 		downl*) oui_download;;
-		
+
 		#Display manufacturer name
 		??:??:??:??:??:??) oui_manufacturer "$1";;
-		
+
 		#Invalid parameter
 		*) display_help;;
 	esac
@@ -562,25 +562,25 @@ oui_cmd() {
 #Show log contents
 log_read() {
 	load_config
-	
+
 	case "$LOG" in
 		#LOG disabled
 		0)
 			>&2 echo "Logging is disabled."
 			exit 2
 		;;
-		
+
 		#Syslog
 		1)
 			logread |
 				grep 'ip6neigh: ' |
 				grep -i -E "$1"
 		;;
-		
+
 		#File
 		*) [ -f "$LOG" ] &&	grep -i -E "$1" "$LOG";;
-	esac 
-	
+	esac
+
 	return 0
 }
 


### PR DESCRIPTION
…ddr, ip6neigh-svc, ip6neigh, and related scripts

- Removed unnecessary blank lines and adjusted indentation for consistency.
- Improved readability by aligning comments and code structure.
- Ensured consistent use of spaces around operators and after commas.
- Updated usage comments in test_libip6addr.sh for clarity.
- Enhanced echo statements in ip6neigh-svc.sh for better user guidance.